### PR TITLE
chore(web): install agent skills + Makefile lifecycle targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ web/target/
 web/bin/
 observability/.env.obs
 observability/jmx_exporter/jmx_prometheus_javaagent-1.5.0.jar
+
+# Agent skills (installed by `npx skills` — restore via `make -C web skills-restore`)
+web/.agents/skills/

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,36 @@
+# ─── Cross-platform support ────────────────────────────────────────
+# On Windows, use Git Bash's sh.exe so POSIX utilities (grep, awk,
+# git, npx …) are available in recipe lines.
+ifeq ($(OS),Windows_NT)
+  SHELL := C:/Program Files/Git/bin/sh.exe
+  .SHELLFLAGS := -c
+endif
+
+.PHONY: help skills-list skills-update skills-restore
+
+default: help
+
+##@ Skills
+
+skills-list: ## List project skills installed via skills-lock.json
+	@npx skills list -p
+
+skills-update: ## Update project skills and show what changed
+	@npx skills update -p -y
+	@echo ""
+	@echo "Changed skill files:"
+	@git diff --name-only -- .agents/skills skills-lock.json || true
+
+skills-restore: ## Restore pinned skills from skills-lock.json
+	@npx skills experimental_install
+
+##@ General
+
+help: ## Show this help message
+	@awk ' \
+		/^##@/      { printf "\n\033[1m%s\033[0m\n", substr($$0, 5); next } \
+		/^[a-zA-Z_-]+:.*##/ { \
+			split($$0, parts, ":.*## *"); \
+			printf "  \033[36m%-20s\033[0m %s\n", parts[1], parts[2] \
+		} \
+	' $(MAKEFILE_LIST) || true

--- a/web/skills-lock.json
+++ b/web/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "create-spring-boot-java-project": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "skillPath": "skills/create-spring-boot-java-project/SKILL.md",
+      "computedHash": "f295d4ddc256642e850e7d7a40526ed10aad2801e0c202e0b4c78506c52f4461"
+    },
+    "sentry-workflow": {
+      "source": "getsentry/sentry-for-ai",
+      "sourceType": "github",
+      "skillPath": "skills/sentry-workflow/SKILL.md",
+      "computedHash": "00a62d74aa26a9007d74532ab405b16684386e59c4121a5496f0059206683c6e"
+    }
+  }
+}


### PR DESCRIPTION
Adds 2 agent skills for the `web/` workspace via the `skills` CLI (lockfile in `web/skills-lock.json`):

- `github/awesome-copilot@create-spring-boot-java-project` (Snyk: High — markdown-only skill, risk is from upstream repo deps not anything that runs locally)
- `getsentry/sentry-for-ai@sentry-workflow` (Med Risk)

Also adds:
- New `web/Makefile` with `skills-list` / `skills-update` / `skills-restore` / `help` targets
- gitignore entry for `web/.agents/skills/` (reproducible from lockfile)

After clone, run `make -C web skills-restore`.